### PR TITLE
Refunds return remaining portion of original contribution

### DIFF
--- a/smart-contracts/ethereum/contracts/Contribution.sol
+++ b/smart-contracts/ethereum/contracts/Contribution.sol
@@ -91,8 +91,8 @@ contract Contribution is Testable {
 
         uint contributedAmount = fundingStorage.getContributionAmount(_projectId, contributorId);
         uint percentageFundsReleased = fundingStorage.getProjectPercentageFundsReleased(_projectId);
-        uint maxPercentage = 100;
-        uint fundsToRefund = contributedAmount.mul(maxPercentage.sub(percentageFundsReleased)).div(100);
+        uint percentageFundsRemaining = 100 - percentageFundsReleased;
+        uint fundsToRefund = contributedAmount.mul(percentageFundsRemaining).div(100);
 
         FundingStorage fs = FundingStorage(fundingStorage);
         FundingVault fv = FundingVault(fs.getContractAddress("FundingVault"));

--- a/smart-contracts/ethereum/contracts/Contribution.sol
+++ b/smart-contracts/ethereum/contracts/Contribution.sol
@@ -90,10 +90,13 @@ contract Contribution is Testable {
         require(fundingStorage.getContributesToProject(contributorId, _projectId), "This address has not contributed to this project.");
 
         uint contributedAmount = fundingStorage.getContributionAmount(_projectId, contributorId);
+        uint percentageFundsReleased = fundingStorage.getProjectPercentageFundsReleased(_projectId);
+        uint maxPercentage = 100;
+        uint fundsToRefund = contributedAmount.mul(maxPercentage.sub(percentageFundsReleased)).div(100);
 
         FundingStorage fs = FundingStorage(fundingStorage);
         FundingVault fv = FundingVault(fs.getContractAddress("FundingVault"));
-        fv.withdrawEth(contributedAmount, msg.sender);
+        fv.withdrawEth(fundsToRefund, msg.sender);
     }
 
     function getProjectFundsRaised(uint _projectId) external view returns (uint) {

--- a/smart-contracts/ethereum/contracts/libraries/ProjectMilestoneCompletionHelpersLibrary.sol
+++ b/smart-contracts/ethereum/contracts/libraries/ProjectMilestoneCompletionHelpersLibrary.sol
@@ -14,6 +14,8 @@ library ProjectMilestoneCompletionHelpersLibrary {
     function releaseMilestoneFunds(FundingStorage _fundingStorage, uint _projectId, uint _index) internal {
         uint fundsRaised = _fundingStorage.getProjectFundsRaised(_projectId);
         uint percentageToSend = _fundingStorage.getTimelineMilestonePercentage(_projectId, _index);
+        uint currentFundsReleased = _fundingStorage.getProjectPercentageFundsReleased(_projectId);
+        _fundingStorage.setProjectPercentageFundsReleased(_projectId, currentFundsReleased + percentageToSend);
         uint amountToSend = fundsRaised.mul(percentageToSend).div(100);
         address developer = _fundingStorage.getProjectDeveloper(_projectId);
         FundingVault fv = FundingVault(_fundingStorage.getContractAddress("FundingVault"));

--- a/smart-contracts/ethereum/contracts/libraries/storage/ContributionStorageAccess.sol
+++ b/smart-contracts/ethereum/contracts/libraries/storage/ContributionStorageAccess.sol
@@ -26,6 +26,7 @@ library ContributionStorageAccess {
             mapping(uint (projID) => mapping (uint (id) => uint)) contributionAmount    (contribution.contributionAmount)
             mapping(uint (projID) => address[]) contributorList                         (contribution.contributorList)
             mapping(uint (projID) => uint fundsRaised)                                  (contribution.fundsRaised)
+            mapping(uint (projID) => uint percentageFundsReleased)                      (contribution.percentageFundsReleased)
 
         There is a registry of contributors:
             mapping(address => uint (id)) contributorMap                                (contribution.contributorMap)
@@ -110,6 +111,10 @@ library ContributionStorageAccess {
         return _fundingStorage.getUint(keccak256(abi.encodePacked("contribution.fundsRaised", _projectId)));
     }
 
+    function getProjectPercentageFundsReleased(FundingStorage _fundingStorage, uint _projectId) internal view returns (uint) {
+        return _fundingStorage.getUint(keccak256(abi.encodePacked("contribution.percentageFundsReleased", _projectId)));
+    }
+
 
 
     // Setters
@@ -158,5 +163,9 @@ library ContributionStorageAccess {
 
     function setProjectFundsRaised(FundingStorage _fundingStorage, uint _projectId, uint _fundsRaised) internal {
         _fundingStorage.setUint(keccak256(abi.encodePacked("contribution.fundsRaised", _projectId)), _fundsRaised);
+    }
+
+    function setProjectPercentageFundsReleased(FundingStorage _fundingStorage, uint _projectId, uint _fundsReleased) internal {
+        _fundingStorage.setUint(keccak256(abi.encodePacked("contribution.percentageFundsReleased", _projectId)), _fundsReleased);
     }
 }


### PR DESCRIPTION
Addresses issue #29. 

Changes:

- When milestone funds are released to a developer, percentageFundsReleased is updated in storage
- When a refund is requested, the amount sent back to the user is amountContributed * (100 - percentageFundsReleased) / 100.  For example, if the original contribution is 10 ETH, and 20% of the milestone funds have already been released, then the refund will be for 8 ETH.
- Truffle tests
